### PR TITLE
build: bump `vercel-php` from 0.5.1 to 0.5.2

### DIFF
--- a/Vercel/Deploy.html
+++ b/Vercel/Deploy.html
@@ -189,7 +189,7 @@
                     var filedata = new Array();
                     let tmp = {
                         "file": "vercel.json",
-                        "data": '{ "functions": { "api/index.php": { "runtime": "vercel-php@0.5.1" } }, "routes": [ { "src": "/(.*)",  "dest": "/api/index.php" } ] }'
+                        "data": '{ "functions": { "api/index.php": { "runtime": "vercel-php@0.5.2" } }, "routes": [ { "src": "/(.*)",  "dest": "/api/index.php" } ] }'
                     }
                     filedata.push(tmp);
                     var loadedNum = 0;
@@ -241,7 +241,7 @@
                     "target": "production",
                     "functions": {
                         "api/index.php": {
-                            "runtime": "vercel-php@0.5.1"
+                            "runtime": "vercel-php@0.5.2"
                         }
                     },
                     "routes": [

--- a/Vercel/DeployFolder.html
+++ b/Vercel/DeployFolder.html
@@ -52,7 +52,7 @@
                 var filedata = new Array();
                 let tmp = {
                     "file": "vercel.json",
-                    "data": '{ "functions": { "api/index.php": { "runtime": "vercel-php@0.5.1" } }, "routes": [ { "src": "/(.*)",  "dest": "/api/index.php" } ] }'
+                    "data": '{ "functions": { "api/index.php": { "runtime": "vercel-php@0.5.2" } }, "routes": [ { "src": "/(.*)",  "dest": "/api/index.php" } ] }'
                 }
                 filedata.push(tmp);
                 for (file of files) {
@@ -98,7 +98,7 @@
                     "target": "production",
                     "functions": {
                         "api/index.php": {
-                            "runtime": "vercel-php@0.5.1"
+                            "runtime": "vercel-php@0.5.2"
                         }
                     },
                     "routes": [


### PR DESCRIPTION
`vercel-php@0.5.2` has bumped minimum node version from 12.x to 14.x. Node.js 12 will no longer be supported on Vercel.

fix [#632](https://github.com/qkqpttgf/OneManager-php/issues/632)